### PR TITLE
Add an alternative lookup for the method __delete__ for data descriptors

### DIFF
--- a/desugar/builtins.py
+++ b/desugar/builtins.py
@@ -116,7 +116,9 @@ class object:
         elif type_attr is not NOTHING:
             return type_attr
         else:
-            raise AttributeError(f"{self_type.__name__!r} object has no attribute {attr!r}")
+            raise AttributeError(
+                f"{self_type.__name__!r} object has no attribute {attr!r}"
+            )
 
     def __eq__(self, other, /) -> Union[Literal[True], NotImplemented]:
         """Implement equality via identity.

--- a/desugar/builtins.py
+++ b/desugar/builtins.py
@@ -98,8 +98,10 @@ class object:
                 if "__get__" in type_attr_type.__dict__:
                     descriptor_type_get = type_attr_type.__dict__["__get__"]
                     # Include/descrobject.h:PyDescr_IsData
-                    if ("__set__" in type_attr_type.__dict__
-                            or "__delete__" in type_attr_type.__dict__):
+                    if (
+                        "__set__" in type_attr_type.__dict__
+                        or "__delete__" in type_attr_type.__dict__
+                    ):
                         # Data descriptor.
                         return descriptor_type_get(type_attr, self, self_type)
                     else:

--- a/desugar/builtins.py
+++ b/desugar/builtins.py
@@ -115,7 +115,7 @@ class object:
             else:
                 return type_attr
         else:
-            raise AttributeError(f"{self.__name__!r} object has no attribute {attr!r}")
+            raise AttributeError(f"{self_type.__name__!r} object has no attribute {attr!r}")
 
     def __eq__(self, other, /) -> Union[Literal[True], NotImplemented]:
         """Implement equality via identity.

--- a/desugar/builtins.py
+++ b/desugar/builtins.py
@@ -109,11 +109,10 @@ class object:
 
         if attr in self.__dict__:
             return self.__dict__[attr]
+        elif descriptor_type_get is not NOTHING:
+            return descriptor_type_get(type_attr, self, self_type)
         elif type_attr is not NOTHING:
-            if descriptor_type_get is not NOTHING:
-                return descriptor_type_get(type_attr, self, self_type)
-            else:
-                return type_attr
+            return type_attr
         else:
             raise AttributeError(f"{self_type.__name__!r} object has no attribute {attr!r}")
 

--- a/desugar/builtins.py
+++ b/desugar/builtins.py
@@ -98,7 +98,8 @@ class object:
                 if "__get__" in type_attr_type.__dict__:
                     descriptor_type_get = type_attr_type.__dict__["__get__"]
                     # Include/descrobject.h:PyDescr_IsData
-                    if "__set__" in type_attr_type.__dict__:
+                    if ("__set__" in type_attr_type.__dict__
+                            or "__delete__" in type_attr_type.__dict__):
                         # Data descriptor.
                         return descriptor_type_get(type_attr, self, self_type)
                     else:


### PR DESCRIPTION
From your (excellent) blog article [*Unravelling attribute access in Python*](https://snarky.ca/unravelling-attribute-access-in-python/):

> There are two kinds of descriptors: data and non-data. Both kind of descriptors define a `__get__` method for getting what the attribute should be. Data descriptors also define `__set__` and `__del__` methods while non-data descriptors do not; `property` is a data descriptor, `classmethod` and `staticmethod` are non-data descriptors.

But the alternative lookup for the method `__delete__` (note also the typo `__del__` in your article) is absent from your code.